### PR TITLE
Prioritize breaking-change detection in release rules

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -10,6 +10,10 @@ export default {
       {
         releaseRules: [
           {
+            breaking: true,
+            release: 'major',
+          },
+          {
             type: 'chore',
             scope: 'deps',
             release: 'patch',


### PR DESCRIPTION
Custom releaseRules for `refactor`, `docs`, etc. matched on type alone, so a `refactor!:` commit was caught by the patch rule before the rule for breaking changes ever ran, causing a patch bump instead of major.